### PR TITLE
Add SSL/TLS selection for SMTP connections

### DIFF
--- a/config_manager.py
+++ b/config_manager.py
@@ -12,7 +12,8 @@ DEFAULT_CONFIG = {
         "port": 587,
         "user": "user@example.com",
         "password": "", # Store passwords securely, e.g., using keyring or encrypted
-        "use_tls": True
+        "use_tls": True,
+        "use_ssl": False # New option for direct SSL
     },
     "scheduled_tasks": [
         # Example task structure:
@@ -63,11 +64,17 @@ def load_config():
                     if key not in config_data:
                         config_data[key] = DEFAULT_CONFIG[key]
                     elif key == "smtp_settings": # Ensure all smtp_settings sub-keys are present
-                        for sub_key in DEFAULT_CONFIG["smtp_settings"]:
+                        for sub_key, default_value in DEFAULT_CONFIG["smtp_settings"].items():
                             if sub_key not in config_data["smtp_settings"]:
-                               config_data["smtp_settings"][sub_key] = DEFAULT_CONFIG["smtp_settings"][sub_key]
+                               config_data["smtp_settings"][sub_key] = default_value
                     elif key == "scheduled_tasks": # Ensure tasks have new fields
                         config_data[key] = [_ensure_task_fields(task) for task in config_data[key]]
+
+                # Final check for smtp_settings if it existed but was missing newer sub-keys
+                if "smtp_settings" in config_data:
+                    for sub_key, default_value in DEFAULT_CONFIG["smtp_settings"].items():
+                        if sub_key not in config_data["smtp_settings"]:
+                            config_data["smtp_settings"][sub_key] = default_value
 
                 print(f"ConfigManager: Configuration loaded from {config_path}")
                 return config_data

--- a/gemini_client.py
+++ b/gemini_client.py
@@ -21,23 +21,32 @@ class GeminiClient:
         Simulates getting a response from Gemini.
         If search_internet is True, it simulates an internet search first.
         """
-        print(f"GeminiClient: Received prompt: '{prompt}', Search Internet: {search_internet}")
+        print(f"GeminiClient INFO: Received prompt for Gemini: '{prompt}', Search Internet: {search_internet}")
 
         if not self.api_key:
-            return "Error: API Key not configured for GeminiClient."
+            error_message = "Error: API Key not configured for GeminiClient."
+            print(f"GeminiClient ERROR: Failed to get response. Reason: {error_message}")
+            return error_message
 
         # Simulate network delay and processing
+        print("GeminiClient INFO: Simulating call to Gemini API...")
         time.sleep(1) 
+
+        # Simulate a potential error during API call for testing logging
+        # if "error_test" in prompt.lower():
+        #     error_message = "Simulated API error from Gemini."
+        #     print(f"GeminiClient ERROR: Failed to get response from Gemini. Reason: {error_message}")
+        #     return f"Error: {error_message}"
 
         simulated_response = f"Simulated Gemini response for: '{prompt}'."
 
         if search_internet:
-            print("GeminiClient: Simulating internet search...")
+            print("GeminiClient INFO: Simulating internet search as part of Gemini interaction...")
             time.sleep(0.5) # Simulate search delay
             search_result = f"Simulated internet search result for '{prompt}'."
             simulated_response = f"{search_result}\n\n{simulated_response}"
         
-        print(f"GeminiClient: Sending back: '{simulated_response}'")
+        print(f"GeminiClient SUCCESS: Successfully received simulated response from Gemini: '{simulated_response}'")
         return simulated_response
 
 if __name__ == '__main__':


### PR DESCRIPTION
This commit introduces the ability for users to choose between STARTTLS and direct SSL for SMTP email sending.

Key changes:

-   **config_manager.py**:
    -   Added `use_ssl` (default: `False`) to SMTP settings in
        `DEFAULT_CONFIG`.
    -   Ensured `load_config` migrates older configs by adding
        `use_ssl` if missing.

-   **email_sender.py**:
    -   `EmailSender.__init__` now accepts a `use_ssl` parameter.
    -   Connection logic updated to use `smtplib.SMTP_SSL` if
        `use_ssl` is true, otherwise uses `smtplib.SMTP` with
        optional STARTTLS based on the `use_tls` flag.
    -   Prioritizes SSL if both SSL and STARTTLS are selected.
    -   Improved logging to reflect the chosen security mode.

-   **gui.py**:
    -   SMTP settings dialog now includes a
        "Use SSL directly (e.g., for port 465)" checkbox.
    -   The "Use TLS" checkbox is clarified to
        "Use STARTTLS (e.g., for port 587)".
    -   The choice is saved in the configuration.
    -   A warning is shown if both options are checked.
    -   Test email functionality now uses the selected SSL/TLS setting.

-   **scheduler.py**:
    -   Scheduled tasks now pass the configured `use_ssl` setting
        to `EmailSender`.

This provides users more flexibility in configuring email sending, especially for SMTP servers that require direct SSL connections (e.g., on port 465).