### PR TITLE
Fix: Ensure tasks persist and scheduler starts correctly

### DIFF
--- a/config_manager.py
+++ b/config_manager.py
@@ -92,7 +92,8 @@ def load_config():
         return json.loads(json.dumps(DEFAULT_CONFIG))
     except Exception as e:
         print(f"ConfigManager: An error occurred loading config: {e}. Using default configuration.")
-        return DEFAULT_CONFIG
+        # Return a deep copy to prevent modification of the global DEFAULT_CONFIG
+        return json.loads(json.dumps(DEFAULT_CONFIG))
 
 def save_config(config_data):
     """Saves the given configuration data to the JSON file."""


### PR DESCRIPTION
- Modified config_manager.py to return a deep copy of DEFAULT_CONFIG in all error cases during load_config. This prevents accidental modification of the global DEFAULT_CONFIG and ensures that tasks are correctly loaded and appended, resolving the issue of tasks disappearing when new ones are added.
- This fix also resolves the issue where the scheduler would report 'no enabled tasks' because the task list was erroneously empty due to the config loading problem.