### PR TITLE
Fix: Update Gemini model to models/gemini-2.0-flash

### DIFF
--- a/gemini_client.py
+++ b/gemini_client.py
@@ -13,8 +13,8 @@ class GeminiClient:
         if api_key:
             try:
                 genai.configure(api_key=api_key)
-                self.model = genai.GenerativeModel('gemini-pro')
-                print(f"GeminiClient initialized and configured with API key.")
+                self.model = genai.GenerativeModel('models/gemini-2.0-flash')
+                print(f"GeminiClient initialized and configured with API key for models/gemini-2.0-flash.")
             except Exception as e:
                 print(f"GeminiClient ERROR: Failed to configure Gemini with API key: {e}")
                 traceback.print_exc()


### PR DESCRIPTION
Updated the Gemini client to use 'models/gemini-2.0-flash' instead of 'gemini-pro' to resolve the 404 error. This change is based on the available models for the v1beta API version.